### PR TITLE
Updating resources

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -86,9 +86,9 @@ if args.command == "create" and args.dir:
     splitter.write_notebook(solution_path, solution_cells)
     splitter.write_notebook('index', lesson_cells)
     os.remove("curriculum.ipynb")
-    generate_readme('index.ipynb', '.' + os.sep, 'README')
+    generate_readme('index.ipynb',  'README')
     generate_readme(solution_path + '.ipynb', 
-                    solution_dir + os.sep, 'README')
+                    solution_dir + os.sep + 'README')
     print()
     print(color.BOLD, color.CYAN, '📒 Solution and Lesson Notebooks have been created!', color.END)
     print()
@@ -106,12 +106,12 @@ elif args.command == "create":
     repo = GitModel()
 
     # Ensure the curriculum branch is checked out
-    if repo.active_branch.name != 'curriculum':
+    if repo.active_branch.name.lower() != 'curriculum':
         print()
         raise ValueError(f'You are currently on {repo.active_branch.name}.\nPlease checkout the curriculum branch.')
 
     # Generate Curriculum Readme
-    generate_readme('index.ipynb', '.' + os.sep, 'README')
+    generate_readme('index.ipynb', 'README')
 
     # Commit curriculum changes
     print('Commiting curriculum changes...')
@@ -126,7 +126,7 @@ elif args.command == "create":
         origin = repo.remote()
         origin.push('master')
 
-    # Create solution is doesn't exist
+    # Create solution if doesn't exist
     if 'solution' not in os.listdir(branches):
         print('Creating a solution branch...')
         solution = repo.create_head('solution')
@@ -142,7 +142,7 @@ elif args.command == "create":
     repo.git.checkout('master')
     repo.git.checkout('curriculum', '.')
     splitter.write_notebook('index', lesson_cells)
-    generate_readme('index.ipynb', '.' + os.sep, 'README')
+    generate_readme('index.ipynb','README')
     repo.add_and_commit(commit_msg)
 
     # Update solution branch
@@ -150,7 +150,7 @@ elif args.command == "create":
     repo.git.checkout('solution')
     repo.git.checkout('curriculum', '.')
     splitter.write_notebook('index', solution_cells)
-    generate_readme('index.ipynb', '.' + os.sep, 'README')
+    generate_readme('index.ipynb', 'README')
     repo.add_and_commit(commit_msg)
 
     # Push changes
@@ -206,7 +206,7 @@ if args.command == 'generate':
     if not os.path.isfile(source_notebook_path):
         raise ValueError('The assignment notebook must be named index.ipynb')
     # Save source readme to master branch
-    generate_readme(source_notebook_path, source_path, 'README')
+    generate_readme(source_notebook_path, 'README' )
 
     # Create a git interface
     repo = GitModel()
@@ -233,7 +233,7 @@ if args.command == 'generate':
     release_notebook_path = os.path.join(release_path, 'index.ipynb')
 
     # Save release readme to master branch
-    generate_readme(release_notebook_path, source_path, 'README')
+    generate_readme(release_notebook_path, 'README')
 
     # Commit changes to master branch
     repo.add_and_commit(commit_msg="Update release readme")

--- a/dscreate/create/SplitNotebook.py
+++ b/dscreate/create/SplitNotebook.py
@@ -63,6 +63,8 @@ class SplitNotebook:
                     lesson_cells.append(cell)
                     if self.dir:
                         solution_cells.append(placeholder) 
+                    else:
+                        solution_cells.append(cell)
             count += 1 
         return lesson_cells, solution_cells 
 

--- a/dscreate/create/readme.py
+++ b/dscreate/create/readme.py
@@ -5,7 +5,7 @@ from nbconvert import MarkdownExporter
 from nbconvert.writers import FilesWriter
 from traitlets.config import Config
     
-def generate_readme(notebook_path, dir_path, filename):
+def generate_readme(notebook_path, filename):
     """
     Saves a jupyter notebook as a README.md file using nbformat and nbconvert
 
@@ -17,37 +17,16 @@ def generate_readme(notebook_path, dir_path, filename):
     Returns:
     None
     """
-    output_path = os.path.join(dir_path, 'README.md')
-    index_files = os.path.join(dir_path, 'index_files')
-    input_path = os.path.join(index_files, filename + '.md')
-    notebook = nbformat.read(notebook_path, nbformat.NO_CONVERT)
+
+    notebook = nbformat.read(notebook_path, as_version=4)
+
+    resources = {}
+    resources['unique_key'] = 'index'
+    resources['output_files_dir'] = 'index_files'
+
     mark_exporter = MarkdownExporter()
-    (output, resources) = mark_exporter.from_notebook_node(notebook)
-
-
-    if not os.path.isdir(index_files):
-        os.mkdir(index_files)
-    if os.path.isfile(output_path):
-        os.remove(output_path)
-    if os.path.isfile(input_path):
-        os.remove(input_path)
+    (output, resources) = mark_exporter.from_notebook_node(notebook, resources=resources)
 
     c = Config()
-    c.FilesWriter.build_directory = index_files
     fw = FilesWriter(config=c)
     fw.write(output, resources, notebook_name=filename)
-    
-    old_readme_file = open(input_path)
-    old_readme = old_readme_file.read()
-    old_readme_file.close()
-    os.remove(input_path)
-    pattern = '!\[[^\]]*\]\((.*?)\s*("(?:.*[^"])")?\s*\)'
-    image_paths = re.findall(pattern, old_readme)
-
-    new_readme = str(old_readme)
-    for path in image_paths:
-        new_readme = new_readme.replace(path[0], 'index_files' + os.sep + path[0])
-
-    readme_file = open(output_path, 'w')
-    readme_file.write(new_readme)
-    readme_file.close()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='dscreate',
-      version='0.1.86',
+      version='0.1.87',
       description='Flatiron Iron School Data Science Tools',
       url='http://github.com/learn-co-curriculum/dscreate',
       author='Joél Collins',


### PR DESCRIPTION
## Primary Update

**Problem**

Previously, the image paths in the readme were being updated manually with regex. If image is embedded in a markdown cell, the image path should not be updated. The regex approach was updating the paths for this type of image and as a result, they were failing to render.

**Change**

The regex approach has been removed. Instead, the file path for storing readme images is added to a `resources` dictionary, and passed into the markdown exporter. `nbconvert` uses this path to update the output images and doesn't apply an update to images embedded in markdown. 

## Changed Made

**`generate_readme` received the following updates:**

- The positional parameter `dir_path` was removed. This could be added back in if a need is found for saving readme files outside of the cwd, but for now no existing workflow needs this feature.
- The FileWriter `build_directory` was removed.
- A resources dictionary was created based on `nbconvert`'s [src code](https://github.com/jupyter/nbconvert/blob/53c46d2785bfbaebdcb1ab7a959f7c09e9209477/nbconvert/nbconvertapp.py#L390)
- The resources dictionary is passed into the MarkdownExporter's `from_notebook_node` method.

**`SplitNotebook` received the following updates:**
- Lesson cells are now appended to the solution notebook.